### PR TITLE
Alfa network awus036ach support

### DIFF
--- a/virtualmachines/kali/Vagrantfile
+++ b/virtualmachines/kali/Vagrantfile
@@ -11,7 +11,8 @@ Vagrant.configure("2") do |config|
   config.vm.box = "kalilinux/rolling"
 
   #provisioning
-  config.vm.provision :shell, path: "provision.sh"
+  config.vm.provision :shell, path: "provision/core.sh"
+  config.vm.provision :shell, path: "provision/adapters/alfa_awus036ach.sh"
 
 
   if Vagrant.has_plugin?("vagrant-vbguest") then

--- a/virtualmachines/kali/provision.sh
+++ b/virtualmachines/kali/provision.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-apt-get update
-
-

--- a/virtualmachines/kali/provision/adapters/alfa_awus036ach.sh
+++ b/virtualmachines/kali/provision/adapters/alfa_awus036ach.sh
@@ -1,0 +1,11 @@
+#!/bin/bash 
+
+sudo apt remove realtek-rtl88xxau-dkms 
+sudo apt purge realtek-rtl88xxau-dkms
+sudo apt autoremove && apt autoclean
+
+
+mkdir drivers &&cd drivers
+git clone https://github.com/aircrack-ng/rtl8812au
+cd rtl8812au
+make && make install

--- a/virtualmachines/kali/provision/core.sh
+++ b/virtualmachines/kali/provision/core.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+echo "deb-src http://http.kali.org/kali kali-rolling main non-free contrib" | sudo tee -a /etc/apt/sources.list
+sudo apt update -y
+sudo apt upgrade -y
+sudo apt dist-upgrade 
+
+sudo apt install aptitude -y
+sudo apt install build-essential bc libelf-dev linux-headers-`uname -r` -y
+


### PR DESCRIPTION
# Description

In this PR are added the drivers for the Alfa network `AWUS036ACH` in the provision step for vagrant
