### PR TITLE
Kali-wifi

### DIFF
--- a/virtualmachines/kali-wifi/Vagrantfile
+++ b/virtualmachines/kali-wifi/Vagrantfile
@@ -1,0 +1,32 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+
+  config.vm.box = "cristianchaparroa/kali-netinstall"
+  config.vm.box_version = "2022.2"
+
+  #provisioning
+  config.vm.provision :shell, path: "provision/core.sh"
+  config.vm.provision :shell, path: "provision/adapters/alfa_awus036ach.sh"
+
+
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+          config.vbguest.auto_update = false
+  end
+
+  # Its required to install on host system the virtualbox extension pack
+  #
+  # Enable USB Controller on VirtualBox
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize ["modifyvm", :id, "--usb", "on"]
+    vb.customize ["modifyvm", :id, "--usbehci", "on"]
+  end
+  
+end

--- a/virtualmachines/kali-wifi/provision/adapters/alfa_awus036ach.sh
+++ b/virtualmachines/kali-wifi/provision/adapters/alfa_awus036ach.sh
@@ -1,0 +1,11 @@
+#!/bin/bash 
+
+sudo apt remove realtek-rtl88xxau-dkms 
+sudo apt purge realtek-rtl88xxau-dkms
+sudo apt autoremove && apt autoclean
+sudo apt install realtek-rtl88xxau-dkms -y 
+
+mkdir drivers &&cd drivers
+git clone https://github.com/aircrack-ng/rtl8812au
+cd rtl8812au
+make && make install

--- a/virtualmachines/kali-wifi/provision/core.sh
+++ b/virtualmachines/kali-wifi/provision/core.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+
+sudo apt-get update -y
+sudo apt-get upgrade -y
+sudo apt-get dist-upgrade 
+
+sudo apt-get install aptitude -y
+sudo apt-get install build-essential bc libelf-dev linux-headers-`uname -r` -y
+
+# wifi tools
+sudo apt install net-tools wireless-tools -y 
+
+# kali linux tools
+sudo apt install kali-tools-802-11 -y


### PR DESCRIPTION
# Description 

The following is the vagrant configuration for kali-wifi, a vagrant configuration to be used for wifi tools. It contains:

1. The base of this image is cristianchaparroa/kali-netinstall
2. It contains the meta package kali-tools-802-11
3. It has support for Alfa network adapter AWUS036ACH

This configuration generates the  [kali-tools-802-11](https://app.vagrantup.com/cristianchaparroa/boxes/kali-tools-802-11) box